### PR TITLE
Support url path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ See: [pocketbase/pocketbase](https://github.com/pocketbase/pocketbase)
    docker logs -f pocketbase
    ```
 
+**Available Environment Variables**
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `POSTGRES_URL` | PostgresSQL connection URL (required) | required |
+| `POSTGRES_DATA_DB` | Database name for the PocketBase data | `pb-data` |
+| `POSTGRES_AUX_DB` | Database name for the PocketBase logs data | `pb-auxiliary` |
+| `PB_DATA_DIR` | Directory to store the PocketBase data | `./pb_data` |
+| `PB_PUBLIC_DIR` | Directory to store the public files | `./pb_public` |
+| `PB_HOOKS_DIR` | Directory to store the custom hooks | `./pb_hooks` |
+| `PB_REALTIME_BRIDGE` | Enable/Disable the realtime bridge. Disable it if you don't need horizontal scaling or don't need realtime feature. | `true` |
+| `PB_HTTP_ADDR` | TCP address to listen for the HTTP server | `127.0.0.1:8090` if no domain specified |
+| `PB_HTTPS_ADDR` | TCP address to listen for the HTTPS server | - |
+| `PB_PATH_PREFIX` | URL path prefix for the HTTP server (Useful when reuse same domain for diffrent sites behind nginx) | - |
+| `PB_ALLOWED_ORIGINS` | Comma separated list of allowed CORS origins | `*` (all origins) |
+
 **Limitations**
 
 - Local file system is not synced across multiple instances.

--- a/apis/serve.go
+++ b/apis/serve.go
@@ -33,6 +33,9 @@ type ServeConfig struct {
 	// HttpsAddr is the TCP address to listen for the HTTPS server (eg. "127.0.0.1:443").
 	HttpsAddr string
 
+	// PathPrefix is an optional prefix to use for the API and dashboard routes.
+	PathPrefix string
+
 	// Optional domains list to use when issuing the TLS certificate.
 	//
 	// If not set, the host from the bound server address will be used.
@@ -214,6 +217,11 @@ func Serve(app core.App, config ServeConfig) error {
 			return err
 		}
 
+		// Support path prefix for the API and dashboard routes.
+		if config.PathPrefix != "" {
+			handler = http.StripPrefix(config.PathPrefix, handler)
+		}
+
 		e.Server.Handler = handler
 
 		if config.HttpsAddr == "" {
@@ -275,8 +283,8 @@ func Serve(app core.App, config ServeConfig) error {
 		)
 
 		regular := color.New()
-		regular.Printf("├─ REST API:  %s\n", color.CyanString("%s/api/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")))
-		regular.Printf("└─ Dashboard: %s\n", color.CyanString("%s/_/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")))
+		regular.Printf("├─ REST API:  %s\n", color.CyanString("%s/api/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")+config.PathPrefix))
+		regular.Printf("└─ Dashboard: %s\n", color.CyanString("%s/_/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")+config.PathPrefix))
 	}
 
 	var serveErr error

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,6 +17,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 	var allowedOrigins []string
 	var httpAddr string
 	var httpsAddr string
+	var pathPrefix string
 
 	command := &cobra.Command{
 		Use:          "serve [domain(s)]",
@@ -41,6 +42,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 			err := apis.Serve(app, apis.ServeConfig{
 				HttpAddr:           httpAddr,
 				HttpsAddr:          httpsAddr,
+				PathPrefix:         pathPrefix,
 				ShowStartBanner:    showStartBanner,
 				AllowedOrigins:     allowedOrigins,
 				CertificateDomains: args,
@@ -80,6 +82,13 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 		"https",
 		os.Getenv("PB_HTTPS_ADDR"),
 		"TCP address to listen for the HTTPS server\n(if domain args are specified - default to 0.0.0.0:443, otherwise - default to empty string, aka. no TLS)\nThe incoming HTTP traffic also will be auto redirected to the HTTPS version",
+	)
+
+	command.PersistentFlags().StringVar(
+		&pathPrefix,
+		"pathPrefix",
+		os.Getenv("PB_PATH_PREFIX"),
+		"URL path prefix for the server routes. Must start with a slash (eg. /pb). Useful when reuse same domain for diffrent sites behind nginx",
 	)
 
 	return command


### PR DESCRIPTION
Add a new feature: custom url path prefix.

This is useful when re-use the same domain for different sites behind nginx.

Enable it via command line argument `-pathPrefix /xxx` or environment variable `PB_PATH_PREFIX`.